### PR TITLE
Respect initial position

### DIFF
--- a/config/quad.yaml
+++ b/config/quad.yaml
@@ -21,6 +21,7 @@ quadrotor:
   drag_coefficient: 0.000 # Aerodynamic drag coefficient
   # Inertia matrix [Ixx, Ixy, Ixz, Iyx, Iyy, Iyz, Izx, Izy, Izz] (kg*m^2)
   inertia_matrix: [3.04e-3, 0.0, 0.0, 0.0, 4.55e-3, 0.0, 0.0, 0.0, 2.82e-3]
+  initial_position: [0.5, 0.5, 0.0]
 
 pid_controller:
   pos_gains: # PID gains for position control

--- a/src/config.rs
+++ b/src/config.rs
@@ -328,11 +328,11 @@ where
     let parsed: Value = Deserialize::deserialize(deserializer)?;
 
     match parsed {
-        // If it's a YAML list (sequence), parse as Vec
+        // List of Quadrotors
         Value::Sequence(seq) => {
             serde_yaml::from_value(Value::Sequence(seq)).map_err(D::Error::custom)
         }
-        // If it's a single object (mapping), wrap it in a list
+        // Quadrotor Object
         Value::Mapping(_) => {
             serde_yaml::from_value(Value::Sequence(vec![parsed])).map_err(D::Error::custom)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ impl Quadrotor {
         Ok(Self {
             name: "PengQuad".to_string(),
             config: config.clone(),
-            position: Vector3::zeros(),
+            position: quadrotor_config.initial_position.into(),
             velocity: Vector3::zeros(),
             acceleration: Vector3::zeros(),
             orientation: UnitQuaternion::identity(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,57 +128,6 @@ async fn main() -> Result<(), SimulationError> {
 
     // TODO: just sleep in main thread for simulation duration?
     loop {
-        // If real-time mode is enabled, sleep until the next frame simulation frame
-        if config.real_time {
-            tokio::time::sleep_until(next_frame).await;
-            next_frame += frame_time;
-        }
-        let time = time_step * i as f32;
-        maze.update_obstacles(time_step);
-        update_planner(
-            &mut planner_manager,
-            i,
-            time,
-            config.simulation.simulation_frequency,
-            &quad_state,
-            &maze.obstacles,
-            &planner_config,
-        )?;
-        let (desired_position, desired_velocity, desired_yaw) = planner_manager.update(
-            quad_state.position,
-            quad_state.orientation,
-            quad_state.velocity,
-            time,
-            &maze.obstacles,
-        )?;
-        let (thrust, desired_orientation) = controller.compute_position_control(
-            &desired_position,
-            &desired_velocity,
-            desired_yaw,
-            &quad_state.position,
-            &quad_state.velocity,
-            time_step,
-        );
-
-    let rr = rerun_logger.unwrap();
-    let quad_handles: Vec<tokio::task::JoinHandle<()>> = config
-        .quadrotor
-        .iter()
-        .map(|quadrotor_config| {
-            let quadrotor_sync_clone = Arc::clone(&worker_sync);
-            quadrotor_worker(
-                config.clone(),
-                quadrotor_config.clone(),
-                quadrotor_sync_clone,
-                rr.clone(),
-                rx_maze.clone(),
-            )
-            .unwrap()
-        })
-        .collect();
-
-    // TODO: just sleep in main thread for simulation duration?
-    loop {
         if start_time.elapsed() >= std::time::Duration::from_secs_f32(config.simulation.duration) {
             log::info!("Complete Simulation");
             break;


### PR DESCRIPTION
Initial position needs to be configurable, and the sim should respect initial position.
For multiple vehicles, this is a prerequisite so they don't all spawn on top of each other.