### PR TITLE
first draft eager HyRL

### DIFF
--- a/config/quad_hyrl.yaml
+++ b/config/quad_hyrl.yaml
@@ -66,9 +66,10 @@ planner_schedule:
     planner_type: MinimumJerkLine
     params:
       start_position: [0.0, 0.0, 0.0] # Target end position [x, y, z] (m)
-      start_yaw: 0.0
+      start_yaw: 0
       end_position: [-1.5, 0.0, 1.0] # Target end position [x, y, z] (m)
-      end_yaw: 1.1507944 # Target end yaw angle (rad)
+      # end_yaw: 1.1507944 # Target end yaw angle (rad)
+      end_yaw: 0.0
       duration: 9.0 # Duration of the trajectory (s)
 
   # Minimum Snap Waypoint trajectory
@@ -76,11 +77,11 @@ planner_schedule:
     planner_type: HyRL
     params:
       start_yaw: 0.0
-      num_waypoints: 500
-      url: http://172.26.45.187:50052
+      num_waypoints: 2000
+      url: http://127.0.0.1:50051
       start_position: [-1.5, 0.0, 1.0]
       target_position: [3.5, 0.0, 1.0]
-      duration: 10.0
+      duration: 15.0
 
   # Landing trajectory
   - time: 25.0

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,9 +187,6 @@ fn quadrotor_worker(
         let (mut quad, mass) =
             build_quadrotor(&config, &quadrotor_config).expect("failed to build quadrotor");
 
-        let mut planner_manager =
-            planners::PlannerManager::new(quad.observe(0.0).unwrap().position, 0.0);
-
         let planner_config: Vec<planners::PlannerStepConfig> = config
             .planner_schedule
             .iter()
@@ -200,6 +197,14 @@ fn quadrotor_worker(
                 params: step.params.clone(),
             })
             .collect();
+
+        let mut planner_manager = planners::PlannerManager::new(
+            &planner_config,
+            quad.observe(0.0).unwrap().position,
+            0.0,
+        )
+        .await
+        .expect("Failed to create planner manager");
 
         // Configure controller
         log::info!("Use rerun.io: {}", config.use_rerun);

--- a/src/planners/hyrl.rs
+++ b/src/planners/hyrl.rs
@@ -161,25 +161,25 @@ impl HyRLPlanner {
                 let b = window[1];
                 let delta_x = b.x - a.x;
                 let delta_y = b.y - a.y;
-                // delta_y.atan2(delta_x)
-                0.0
+                delta_y.atan2(delta_x)
+                // 0.0
             })
             // .map(|window| 0.0)
             .collect();
-        // let target_yaw = 0.0;
-        // let blend_window = (num_waypoints as f32 * 0.5) as usize; // number of points to smooth toward 0.0
-        // let len = yaws.len();
+        let target_yaw = 0.0;
+        let blend_window = (num_waypoints as f32 * 0.5) as usize; // number of points to smooth toward 0.0
+        let len = yaws.len();
 
-        // if len >= blend_window as usize {
-        //     for i in 0..blend_window {
-        //         let alpha = (i as f32 + 1.0) / (blend_window as f32);
-        //         yaws[len - blend_window + i] =
-        //             (1.0 - alpha) * yaws[len - blend_window + i] + alpha * target_yaw;
-        //     }
-        // } else if !yaws.is_empty() {
-        //     // Short path, just set final yaw directly
-        //     yaws[len - 1] = target_yaw;
-        // }
+        if len >= blend_window as usize {
+            for i in 0..blend_window {
+                let alpha = (i as f32 + 1.0) / (blend_window as f32);
+                yaws[len - blend_window + i] =
+                    (1.0 - alpha) * yaws[len - blend_window + i] + alpha * target_yaw;
+            }
+        } else if !yaws.is_empty() {
+            // Short path, just set final yaw directly
+            yaws[len - 1] = target_yaw;
+        }
 
         yaws.push_front(*yaws.front().unwrap());
         println!("yaws: {:?}", yaws);

--- a/src/planners/hyrl.rs
+++ b/src/planners/hyrl.rs
@@ -3,6 +3,7 @@ use crate::SimulationError;
 use async_trait::async_trait;
 use nalgebra::Vector3;
 use std::collections::VecDeque;
+use std::f32::consts::PI;
 use tonic::transport::Channel;
 use tonic::transport::Endpoint;
 
@@ -154,35 +155,9 @@ impl HyRLPlanner {
             .collect();
         println!("Drone Waypoints: {:?}", drone_waypoints);
 
-        let mut yaws: VecDeque<f32> = drone_waypoints
-            .windows(2)
-            .map(|window| {
-                let a = window[0];
-                let b = window[1];
-                let delta_x = b.x - a.x;
-                let delta_y = b.y - a.y;
-                delta_y.atan2(delta_x)
-                // 0.0
-            })
-            // .map(|window| 0.0)
-            .collect();
-        let target_yaw = 0.0;
-        let blend_window = (num_waypoints as f32 * 0.5) as usize; // number of points to smooth toward 0.0
-        let len = yaws.len();
-
-        if len >= blend_window as usize {
-            for i in 0..blend_window {
-                let alpha = (i as f32 + 1.0) / (blend_window as f32);
-                yaws[len - blend_window + i] =
-                    (1.0 - alpha) * yaws[len - blend_window + i] + alpha * target_yaw;
-            }
-        } else if !yaws.is_empty() {
-            // Short path, just set final yaw directly
-            yaws[len - 1] = target_yaw;
-        }
-
-        yaws.push_front(*yaws.front().unwrap());
-        println!("yaws: {:?}", yaws);
+        let mut yaws = smooth_yaws_along_path(&drone_waypoints, start_yaw, 0.3);
+        // uncomment this line to use a constant yaw of 0.0
+        // let mut yaws: Vec<f32> = drone_waypoints.iter().map(|_| 0.0).collect();
 
         let segment_duration = duration / (drone_waypoints.len() - 1) as f32;
         let durations = vec![segment_duration; drone_waypoints.len() - 1];
@@ -327,4 +302,51 @@ mod tests {
 
         Ok(())
     }
+}
+
+fn smooth_yaws_along_path(
+    waypoints: &[Vector3<f32>],
+    target_yaw: f32,
+    blend_distance: f32,
+) -> Vec<f32> {
+    use nalgebra::Vector3;
+
+    let mut yaws = Vec::new();
+    let mut distances = vec![0.0];
+
+    // Step 1: Compute raw yaws from heading
+    for window in waypoints.windows(2) {
+        let delta = window[1] - window[0];
+        yaws.push(delta.y.atan2(delta.x));
+        distances.push(distances.last().unwrap() + delta.xy().norm());
+    }
+
+    let total_dist = *distances.last().unwrap();
+    let n = yaws.len();
+    let mut smoothed = vec![0.0; n];
+
+    for i in 0..n {
+        let d = distances[i];
+
+        // Blend in head
+        let head_blend = if d < blend_distance {
+            let alpha = d / blend_distance;
+            (1.0 - alpha) * target_yaw + alpha * yaws[i]
+        } else {
+            yaws[i]
+        };
+
+        // Blend in tail
+        let tail_blend = if d > total_dist - blend_distance {
+            let alpha = (total_dist - d) / blend_distance;
+            (1.0 - alpha) * target_yaw + alpha * head_blend
+        } else {
+            head_blend
+        };
+
+        smoothed[i] = tail_blend;
+    }
+    smoothed.push(*smoothed.last().unwrap());
+
+    smoothed
 }

--- a/src/planners/mod.rs
+++ b/src/planners/mod.rs
@@ -522,9 +522,6 @@ impl PlannerManager {
             #[cfg(feature = "hyrl")]
             "HyRL" => {
                 let url = parse_string(params, "url")?;
-                let client = hyrl::HyRLClient::new(url)?;
-                println!("Creating HyRL Planner---------");
-                // TODO: fetch from eager planner
                 let key: u32 = step
                     .step
                     .map(|s| s as u32)


### PR DESCRIPTION
On planner manager creation, inspect planner configs for planners that should be evaluated eagerly.
Eager planners will be created before the flight begins, and will be looked up from a map when needed, reducing latency during flight.

Future work should support other eager planner types as needed, or eschew eager planning entirely for alternate strategies which perform a hover while they execute function calls on a seperate thread that reports back on a channel, or uses a similar strategy that doesn't require awaiting network calls during flight